### PR TITLE
Renaming of audio_comms namespace to audio_utilities

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-# Copyright 2013-2015 Intel Corporation
+# Copyright 2013-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 
-LOCAL_MODULE := libaudio_comms_utilities
+LOCAL_MODULE := libaudio_utilities
 LOCAL_MODULE_OWNER := intel
 
 include $(BUILD_STATIC_LIBRARY)
@@ -42,7 +42,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 
-LOCAL_MODULE := libaudio_comms_utilities_host
+LOCAL_MODULE := libaudio_utilities_host
 LOCAL_MODULE_OWNER := intel
 
 include $(BUILD_HOST_STATIC_LIBRARY)

--- a/convert/Android.mk
+++ b/convert/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2015
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
     $(LOCAL_PATH)/ \
     $(LOCAL_PATH)/include/
 
-LOCAL_MODULE := libaudio_comms_convert
+LOCAL_MODULE := libaudio_utilities_convert
 LOCAL_MODULE_OWNER := intel
 
 include $(BUILD_STATIC_LIBRARY)
@@ -42,7 +42,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
     $(LOCAL_PATH)/include/
 
 
-LOCAL_MODULE := libaudio_comms_convert_host
+LOCAL_MODULE := libaudio_utilities_convert_host
 LOCAL_MODULE_OWNER := intel
 
 LOCAL_CFLAGS = -O0 --coverage
@@ -62,7 +62,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
     $(LOCAL_PATH)/ \
     $(LOCAL_PATH)/include/
 
-LOCAL_MODULE := libaudio_comms_convert_includes
+LOCAL_MODULE := libaudio_utilities_convert_includes
 LOCAL_MODULE_OWNER := intel
 
 LOCAL_MODULE_TAGS := optional
@@ -76,7 +76,7 @@ include $(CLEAR_VARS)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
-LOCAL_MODULE := libaudio_comms_convert_includes_host
+LOCAL_MODULE := libaudio_utilities_convert_includes_host
 LOCAL_MODULE_OWNER := intel
 
 LOCAL_MODULE_TAGS := optional

--- a/convert/include/convert/convert.hpp
+++ b/convert/include/convert/convert.hpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2013-2015 Intel Corporation
+** Copyright 2013-2017 Intel Corporation
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <cmath>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -361,4 +361,4 @@ inline bool convertTo<std::string, std::string>(const std::string &str, std::str
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/event-listener/Android.mk
+++ b/event-listener/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2015
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_SRC_FILES := EventThread.cpp
 LOCAL_CFLAGS := -Wall -Werror -Wextra
 LOCAL_SHARED_LIBRARIES := libcutils
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities
+LOCAL_STATIC_LIBRARIES := libaudio_utilities
 
 LOCAL_MODULE := libevent-listener
 LOCAL_MODULE_OWNER := intel
@@ -43,7 +43,7 @@ include $(CLEAR_VARS)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
 LOCAL_SRC_FILES := EventThread.cpp
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities
+LOCAL_STATIC_LIBRARIES := libaudio_utilities
 
 LOCAL_MODULE := libevent-listener_static
 LOCAL_MODULE_OWNER := intel
@@ -58,7 +58,7 @@ include $(CLEAR_VARS)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_SRC_FILES := EventThread.cpp
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities_host
+LOCAL_STATIC_LIBRARIES := libaudio_utilities_host
 
 LOCAL_MODULE := libevent-listener_static_host
 LOCAL_MODULE_OWNER := intel

--- a/gcov_flush_with_prop/Android.mk
+++ b/gcov_flush_with_prop/Android.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2015 Intel Corporation
+# Copyright 2013-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SHARED_LIBRARIES := libcutils
 LOCAL_STATIC_LIBRARIES := \
     libproperty \
-    libaudio_comms_convert \
-    libaudio_comms_utilities
+    libaudio_utilities_convert \
+    libaudio_utilities
 
 include $(BUILD_STATIC_LIBRARY)
 endif
@@ -53,8 +53,8 @@ LOCAL_MODULE_TAGS := optional
 
 LOCAL_STATIC_LIBRARIES := \
                      libproperty \
-                     libaudio_comms_convert \
-                     libaudio_comms_utilities
+                     libaudio_utilities_convert \
+                     libaudio_utilities
 
 include $(BUILD_STATIC_LIBRARY)
 

--- a/gcov_flush_with_prop/GcovFlushWithProp.cpp
+++ b/gcov_flush_with_prop/GcovFlushWithProp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ void GcovFlushWithProp::run()
 {
     // Use the property "gcov.flush.force" to communicate between the Android
     // shell and this thread.
-    audio_comms::utilities::Property<bool> gcovFlushForceProp("gcov.flush.force", false);
+    audio_utilities::utilities::Property<bool> gcovFlushForceProp("gcov.flush.force", false);
     bool hasFlush = true;
     while (!stopThread) {
         // Read the property value to take into account Android shell modification

--- a/include/AudioNonCopyable.hpp
+++ b/include/AudioNonCopyable.hpp
@@ -4,7 +4,7 @@
  *
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -48,4 +48,4 @@ private:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/AudioUtilitiesAssert.hpp
+++ b/include/AudioUtilitiesAssert.hpp
@@ -1,10 +1,10 @@
 /*
  * @file
- * audio comms assert facilities for C++.
+ * audio utilities assert facilities for C++.
  *
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 /**
  * Macro to wrap gcc builtin function to specify that a condition is unlikely
  * to happen. */
-#define audio_comms_unlikely(cond) __builtin_expect((cond), 0)
+#define audio_utilities_unlikely(cond) __builtin_expect((cond), 0)
 
 /**
  * This AUDIOUTILITIES_COMPILE_TIME_ASSERT MACRO will fail to compile if the condition is false.
@@ -35,9 +35,9 @@
  * error: 'compileTimeAssertFailure<false>::compileTimeAssertFailure()' is private
  *      YOUR_SOURCE_FILE.cpp:YOUR_ASSERT_LINE: error: within this context
  */
-#define AUDIOUTILITIES_COMPILE_TIME_ASSERT(c) audio_comms::utilities::compileTimeAssertFailure<c>()
+#define AUDIOUTILITIES_COMPILE_TIME_ASSERT(c) audio_utilities::utilities::compileTimeAssertFailure<c>()
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -61,7 +61,7 @@ compileTimeAssertFailure();
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities
 
 #include <utilities/Log.hpp>
 #include <cstdlib> /* assert */
@@ -76,8 +76,8 @@ compileTimeAssertFailure();
  */
 #define AUDIOUTILITIES_ASSERT(cond, iostr)                                                           \
     do {                                                                                         \
-        if (audio_comms_unlikely(!(cond))) {                                                     \
-            audio_comms::utilities::Log::Fatal("AUDIOUTILITIES") << __BASE_FILE__ ":" << __LINE__    \
+        if (audio_utilities_unlikely(!(cond))) {                                                     \
+            audio_utilities::utilities::Log::Fatal("AUDIOUTILITIES") << __BASE_FILE__ ":" << __LINE__    \
                                                              << ": Assertion " #cond " failed: " \
                                                              << iostr;                           \
             abort();                                                                             \

--- a/include/BitField.hpp
+++ b/include/BitField.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2013 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include "AudioUtilitiesAssert.hpp"
 #include <utils/Log.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -46,4 +46,4 @@ private:
 };
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/ConditionVariable.hpp
+++ b/include/ConditionVariable.hpp
@@ -4,7 +4,7 @@
  *
  * @section License
  *
- * Copyright 2015 Intel Corporation
+ * Copyright 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include <cerrno>
 #include <string.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {

--- a/include/DynamicLib.hpp
+++ b/include/DynamicLib.hpp
@@ -4,7 +4,7 @@
  *
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 #include <dlfcn.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities

--- a/include/Mutex.hpp
+++ b/include/Mutex.hpp
@@ -4,7 +4,7 @@
  *
  * @section License
  *
- * Copyright 2013-2015 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 #include <cerrno>
 #include <string.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -109,4 +109,4 @@ private:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/Observable.hpp
+++ b/include/Observable.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2013-2015 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include <vector>
 #include <algorithm>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -80,4 +80,4 @@ private:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/Observer.hpp
+++ b/include/Observer.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2013 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -35,4 +35,4 @@ public:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/Semaphore.hpp
+++ b/include/Semaphore.hpp
@@ -1,7 +1,7 @@
 /*
  * @section License
  *
- * Copyright 2014 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {

--- a/include/utilities/DefaultDelete.hpp
+++ b/include/utilities/DefaultDelete.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -57,4 +57,4 @@ public:
 };
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/EventQueue.hpp
+++ b/include/utilities/EventQueue.hpp
@@ -3,7 +3,7 @@
  *
  * @section License
  *
- * Copyright 2014-2015 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <Semaphore.hpp>
 #include <queue>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -45,7 +45,7 @@ public:
      */
     void post(Event event)
     {
-        audio_comms::utilities::Mutex::Locker locker(mQueueMutex);
+        audio_utilities::utilities::Mutex::Locker locker(mQueueMutex);
         mEventQueue.push(event);
         mEventSemaphore.post();
     }
@@ -56,17 +56,17 @@ public:
     Event wait()
     {
         mEventSemaphore.wait();
-        audio_comms::utilities::Mutex::Locker locker(mQueueMutex);
+        audio_utilities::utilities::Mutex::Locker locker(mQueueMutex);
         Event event = mEventQueue.front();
         mEventQueue.pop();
         return event;
     }
 
 private:
-    audio_comms::utilities::Mutex mQueueMutex; /*< queue lock */
+    audio_utilities::utilities::Mutex mQueueMutex; /*< queue lock */
     std::queue<Event> mEventQueue; /*< queue itself */
-    audio_comms::utilities::Semaphore mEventSemaphore; /*< event semaphore */
+    audio_utilities::utilities::Semaphore mEventSemaphore; /*< event semaphore */
 };
 
 } // utilities
-} // audio_comms
+} // audio_utilities

--- a/include/utilities/FileMapper.hpp
+++ b/include/utilities/FileMapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include <string>
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {

--- a/include/utilities/Log.hpp
+++ b/include/utilities/Log.hpp
@@ -4,7 +4,7 @@
  *
  * @section License
  *
- * Copyright 2015 Intel Corporation
+ * Copyright 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 #include <cutils/log.h>
 #endif
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -272,4 +272,4 @@ typedef GenericLog<DefaultLogTraitList> Log;
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/MethodDelete.hpp
+++ b/include/utilities/MethodDelete.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -41,4 +41,4 @@ public:
 };
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/ScopedTrace.hpp
+++ b/include/utilities/ScopedTrace.hpp
@@ -3,7 +3,7 @@
  *
  * @section License
  *
- * Copyright 2014 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -283,4 +283,4 @@ struct  Trace : ActivableLogger<StaticActivation<activateAtStart>,
 };
 
 } /* namespace utilities */
-} /* namespace audio_comms */
+} /* namespace audio_utilities */

--- a/include/utilities/Thread.hpp
+++ b/include/utilities/Thread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include <pthread.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -33,7 +33,7 @@ namespace utilities
  * The methods start, stop, isStarted and the destructor
  * MUST not be called simultaneously.
  */
-class Thread : private audio_comms::utilities::NonCopyable
+class Thread : private audio_utilities::utilities::NonCopyable
 {
 public:
     /** Create a thread with a name.
@@ -138,4 +138,4 @@ private:
 };
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/TypeList.hpp
+++ b/include/utilities/TypeList.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -46,68 +46,68 @@ struct TypeNull;
 } // detail
 
 #define TYPELIST0 \
-    audio_comms::utilities::detail::TypeNull
+    audio_utilities::utilities::detail::TypeNull
 #define TYPELIST1(A) \
-    audio_comms::utilities::TypeList < A, TYPELIST0 >
+    audio_utilities::utilities::TypeList < A, TYPELIST0 >
 #define TYPELIST2(A, B) \
-    audio_comms::utilities::TypeList < A, TYPELIST1(B) >
+    audio_utilities::utilities::TypeList < A, TYPELIST1(B) >
 #define TYPELIST3(A, B, C) \
-    audio_comms::utilities::TypeList < A, TYPELIST2(B, C) >
+    audio_utilities::utilities::TypeList < A, TYPELIST2(B, C) >
 #define TYPELIST4(A, B, C, D) \
-    audio_comms::utilities::TypeList < A, TYPELIST3(B, C, D) >
+    audio_utilities::utilities::TypeList < A, TYPELIST3(B, C, D) >
 #define TYPELIST5(A, B, C, D, E) \
-    audio_comms::utilities::TypeList < A, TYPELIST4(B, C, D, E) >
+    audio_utilities::utilities::TypeList < A, TYPELIST4(B, C, D, E) >
 #define TYPELIST6(A, B, C, D, E, F) \
-    audio_comms::utilities::TypeList < A, TYPELIST5(B, C, D, E, F) >
+    audio_utilities::utilities::TypeList < A, TYPELIST5(B, C, D, E, F) >
 #define TYPELIST7(A, B, C, D, E, F, G) \
-    audio_comms::utilities::TypeList < A, TYPELIST6(B, C, D, E, F, G) >
+    audio_utilities::utilities::TypeList < A, TYPELIST6(B, C, D, E, F, G) >
 #define TYPELIST8(A, B, C, D, E, F, G, H) \
-    audio_comms::utilities::TypeList < A, TYPELIST7(B, C, D, E, F, G, H) >
+    audio_utilities::utilities::TypeList < A, TYPELIST7(B, C, D, E, F, G, H) >
 #define TYPELIST9(A, B, C, D, E, F, G, H, I) \
-    audio_comms::utilities::TypeList < A, TYPELIST8(B, C, D, E, F, G, H, I) >
+    audio_utilities::utilities::TypeList < A, TYPELIST8(B, C, D, E, F, G, H, I) >
 #define TYPELIST10(A, B, C, D, E, F, G, H, I, J) \
-    audio_comms::utilities::TypeList < A, TYPELIST9(B, C, D, E, F, G, H, I, J) >
+    audio_utilities::utilities::TypeList < A, TYPELIST9(B, C, D, E, F, G, H, I, J) >
 #define TYPELIST11(A, B, C, D, E, F, G, H, I, J, K) \
-    audio_comms::utilities::TypeList < A, TYPELIST10(B, C, D, E, F, G, H, I, J, K) >
+    audio_utilities::utilities::TypeList < A, TYPELIST10(B, C, D, E, F, G, H, I, J, K) >
 #define TYPELIST12(A, B, C, D, E, F, G, H, I, J, K, L) \
-    audio_comms::utilities::TypeList < A, TYPELIST11(B, C, D, E, F, G, H, I, J, K, L) >
+    audio_utilities::utilities::TypeList < A, TYPELIST11(B, C, D, E, F, G, H, I, J, K, L) >
 #define TYPELIST13(A, B, C, D, E, F, G, H, I, J, K, L, M) \
-    audio_comms::utilities::TypeList < A, TYPELIST12(B, C, D, E, F, G, H, I, J, K, L, M) >
+    audio_utilities::utilities::TypeList < A, TYPELIST12(B, C, D, E, F, G, H, I, J, K, L, M) >
 #define TYPELIST14(A, B, C, D, E, F, G, H, I, J, K, L, M, N) \
-    audio_comms::utilities::TypeList < A, TYPELIST13(B, C, D, E, F, G, H, I, J, K, L, M, N) >
+    audio_utilities::utilities::TypeList < A, TYPELIST13(B, C, D, E, F, G, H, I, J, K, L, M, N) >
 #define TYPELIST15(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) \
-    audio_comms::utilities::TypeList < A, TYPELIST14(B, C, D, E, F, G, H, I, J, K, L, M, N, O) >
+    audio_utilities::utilities::TypeList < A, TYPELIST14(B, C, D, E, F, G, H, I, J, K, L, M, N, O) >
 #define TYPELIST16(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) \
-    audio_comms::utilities::TypeList < A, TYPELIST15(B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) >
+    audio_utilities::utilities::TypeList < A, TYPELIST15(B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) >
 #define TYPELIST17(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) \
-    audio_comms::utilities::TypeList < A, TYPELIST16(                 \
+    audio_utilities::utilities::TypeList < A, TYPELIST16(                 \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) >
 #define TYPELIST18(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) \
-    audio_comms::utilities::TypeList < A, TYPELIST17(                    \
+    audio_utilities::utilities::TypeList < A, TYPELIST17(                    \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) >
 #define TYPELIST19(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) \
-    audio_comms::utilities::TypeList < A, TYPELIST18(                       \
+    audio_utilities::utilities::TypeList < A, TYPELIST18(                       \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) >
 #define TYPELIST20(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) \
-    audio_comms::utilities::TypeList < A, TYPELIST19(                          \
+    audio_utilities::utilities::TypeList < A, TYPELIST19(                          \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) >
 #define TYPELIST21(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) \
-    audio_comms::utilities::TypeList < A, TYPELIST20(                             \
+    audio_utilities::utilities::TypeList < A, TYPELIST20(                             \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) >
 #define TYPELIST22(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) \
-    audio_comms::utilities::TypeList < A, TYPELIST21(                                \
+    audio_utilities::utilities::TypeList < A, TYPELIST21(                                \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) >
 #define TYPELIST23(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) \
-    audio_comms::utilities::TypeList < A, TYPELIST22(                                   \
+    audio_utilities::utilities::TypeList < A, TYPELIST22(                                   \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) >
 #define TYPELIST24(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) \
-    audio_comms::utilities::TypeList < A, TYPELIST23(                                      \
+    audio_utilities::utilities::TypeList < A, TYPELIST23(                                      \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) >
 #define TYPELIST25(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) \
-    audio_comms::utilities::TypeList < A, TYPELIST24(                                         \
+    audio_utilities::utilities::TypeList < A, TYPELIST24(                                         \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) >
 #define TYPELIST26(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z) \
-    audio_comms::utilities::TypeList < A, TYPELIST25(                                            \
+    audio_utilities::utilities::TypeList < A, TYPELIST25(                                            \
         B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z) >
 
 /**
@@ -133,4 +133,4 @@ struct Append<TYPELIST0, List>
 };
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/TypeTraits.hpp
+++ b/include/utilities/TypeTraits.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
  * This file aims to implement the c++11 type_traits new header.
  */
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -93,4 +93,4 @@ struct remove_pointer<T *const volatile>
 };
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/include/utilities/UniquePtr.hpp
+++ b/include/utilities/UniquePtr.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <AudioNonCopyable.hpp>
 #include <cstdlib>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -126,4 +126,4 @@ UNIQUE_PTR_OPERATOR(>=)
 #undef UNIQUE_PTR_OPERATOR
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/property/Android.mk
+++ b/property/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2015
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_STATIC_LIBRARIES := \
-    libaudio_comms_convert \
-    libaudio_comms_utilities
+    libaudio_utilities_convert \
+    libaudio_utilities
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := \
     $(LOCAL_PATH)/include/
@@ -54,7 +54,7 @@ LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := optional
 
 LOCAL_STATIC_LIBRARIES := \
-    libaudio_comms_convert_host \
-    libaudio_comms_utilities_host
+    libaudio_utilities_convert_host \
+    libaudio_utilities_host
 
 include $(BUILD_HOST_STATIC_LIBRARY)

--- a/property/Property.cpp
+++ b/property/Property.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #ifndef __ANDROID__
 #include <unistd.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities

--- a/property/include/property/Property.hpp
+++ b/property/include/property/Property.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include <cstdlib>
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -195,7 +195,7 @@ public:
      */
     static bool stringToValue(const std::string &str, T &result)
     {
-        return audio_comms::utilities::convertTo<std::string, T>(str, result);
+        return audio_utilities::utilities::convertTo<std::string, T>(str, result);
     }
 
     /**
@@ -209,7 +209,7 @@ public:
      */
     static bool valueToString(const T &val, std::string &result)
     {
-        return audio_comms::utilities::convertTo<T, std::string>(val, result);
+        return audio_utilities::utilities::convertTo<T, std::string>(val, result);
     }
 };
 
@@ -217,12 +217,12 @@ public:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities
 
 #ifdef __ANDROID__
 
 #include <cutils/properties.h>
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -240,7 +240,7 @@ class AndroidProperty : public SystemProperty
 /** Constructor is made private to prevent the use of this class by any
  * other class than property */
 template <class T, class U>
-friend class audio_comms::utilities::Property;
+friend class audio_utilities::utilities::Property;
 AndroidProperty()
 {
     /** Next assertion are here for consistency checks, if they fail, this
@@ -274,14 +274,14 @@ public:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities
 
 #else // __ANDROID__
 
 #include <map>
 #include <fstream>
 
-namespace audio_comms
+namespace audio_utilities
 {
 
 namespace utilities
@@ -308,7 +308,7 @@ LinuxProperty()
 }
 
 template <class T, class U>
-friend class audio_comms::utilities::Property;
+friend class audio_utilities::utilities::Property;
 
 public:
     /**
@@ -410,5 +410,5 @@ private:
 
 } // namespace utilities
 
-} // namespace audio_comms
+} // namespace audio_utilities
 #endif // __ANDROID__

--- a/remote-parameter/common/Android.mk
+++ b/remote-parameter/common/Android.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Intel Corporation
+# Copyright 2014-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ remote_param_common_shared_lib_target += \
     libcutils
 
 remote_param_common_static_lib += \
-    libaudio_comms_utilities
+    libaudio_utilities
 
 remote_param_common_static_lib_host += \
     $(foreach lib, $(remote_param_common_static_lib), $(lib)_host)

--- a/remote-parameter/common/RemoteParameterConnector.hpp
+++ b/remote-parameter/common/RemoteParameterConnector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Intel Corporation
+ * Copyright 2016-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-class RemoteParameterConnector : private audio_comms::utilities::NonCopyable
+class RemoteParameterConnector : private audio_utilities::utilities::NonCopyable
 {
 public:
     static const uint32_t mCommunicationTimeoutMs = 5000; /**< Timeout. */

--- a/remote-parameter/proxy/Android.mk
+++ b/remote-parameter/proxy/Android.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Intel Corporation
+# Copyright 2014-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ remote_param_proxy_shared_lib_target += \
     libcutils
 
 remote_param_proxy_static_lib += \
-    libaudio_comms_utilities \
+    libaudio_utilities \
     libremote-parameter-common
 
 remote_param_proxy_static_lib_host += \

--- a/remote-parameter/server/Android.mk
+++ b/remote-parameter/server/Android.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Intel Corporation
+# Copyright 2014-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ remote_param_server_shared_lib_target += \
     libevent-listener
 
 remote_param_server_static_lib += \
-    libaudio_comms_utilities \
+    libaudio_utilities \
     libremote-parameter-common
 
 remote_param_server_static_lib_host += \

--- a/remote-parameter/server/RemoteParameterImpl.hpp
+++ b/remote-parameter/server/RemoteParameterImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Intel Corporation
+ * Copyright 2016-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class RemoteParameterBase;
  *              Server Side Remote Parameter callback the set function of the interface.
  *              Server Side Remote Parameter sends the status to the client.
  */
-class RemoteParameterImpl : private audio_comms::utilities::NonCopyable
+class RemoteParameterImpl : private audio_utilities::utilities::NonCopyable
 {
 public:
     /**

--- a/remote-parameter/server/include/RemoteParameterServer.hpp
+++ b/remote-parameter/server/include/RemoteParameterServer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Intel Corporation
+ * Copyright 2016-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ class CEventThread;
 class RemoteParameterBase;
 class RemoteParameterImpl;
 
-class RemoteParameterServer : public IEventListener, private audio_comms::utilities::NonCopyable
+class RemoteParameterServer : public IEventListener, private audio_utilities::utilities::NonCopyable
 {
 public:
     explicit RemoteParameterServer();

--- a/result/include/result/ErrnoResult.hpp
+++ b/result/include/result/ErrnoResult.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <cstring>
 #include <string>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -50,4 +50,4 @@ typedef Result<ErrnoTrait> ErrnoResult;
 
 } /* namespace utilities */
 
-} /* namespace audio_comms */
+} /* namespace audio_utilities */

--- a/result/include/result/Result.hpp
+++ b/result/include/result/Result.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 #include <sstream>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -283,4 +283,4 @@ bool operator!=(typename ErrorTrait::Code code, Result<ErrorTrait> result)
 
 } /* namespace result */
 } /* namespace utilities */
-} /* namespace audio_comms */
+} /* namespace audio_utilities */

--- a/result/test/ErrnoResultUnitTest.cpp
+++ b/result/test/ErrnoResultUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 #include <gtest/gtest.h>
 
-typedef audio_comms::utilities::result::ErrnoResult ErrnoResult;
+typedef audio_utilities::utilities::result::ErrnoResult ErrnoResult;
 
 TEST(ErrnoResult, defaultValueConstructor)
 {

--- a/result/test/ResultUnitTest.cpp
+++ b/result/test/ResultUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ struct TestResult
 const TestResult::Code TestResult::success = A;
 const TestResult::Code TestResult::defaultError = B;
 
-typedef audio_comms::utilities::result::Result<TestResult> Result;
+typedef audio_utilities::utilities::result::Result<TestResult> Result;
 
 TEST(Result, defaultValueConstructor)
 {

--- a/serializer/Android.mk
+++ b/serializer/Android.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright 2013-2015 Intel Corporation
+# Copyright 2013-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,13 +33,13 @@ common_library_local_module := lib$(common_base_name)
 
 common_static_libs := \
     libacresult \
-    libaudio_comms_convert_includes \
-    libaudio_comms_utilities
+    libaudio_utilities_convert_includes \
+    libaudio_utilities
 
 common_static_libs_host := \
     libacresult_host \
-    libaudio_comms_convert_includes_host \
-    libaudio_comms_utilities_host
+    libaudio_utilities_convert_includes_host \
+    libaudio_utilities_host
 
 common_shared_libs_host :=
 

--- a/serializer/include/serializer/framework/Child.hpp
+++ b/serializer/include/serializer/framework/Child.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include "serializer/framework/GetterHelper.hpp"
 #include "serializer/framework/SetterHelper.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -50,4 +50,4 @@ struct Child
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/Collection.hpp
+++ b/serializer/include/serializer/framework/Collection.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -48,4 +48,4 @@ const char *CollectionTrait<_tag, C, I, o>::tag = _tag;
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/ConvertToString.hpp
+++ b/serializer/include/serializer/framework/ConvertToString.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -52,4 +52,4 @@ inline bool toString<bool>(const bool &source, std::string &dest)
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/ConvertorPolicy.hpp
+++ b/serializer/include/serializer/framework/ConvertorPolicy.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <convert.hpp>
 #include <string>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -82,4 +82,4 @@ struct CastConvertor
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/GetterHelper.hpp
+++ b/serializer/include/serializer/framework/GetterHelper.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -66,4 +66,4 @@ struct GetterHelper<Ret (*)(Class), getter>
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/NamedTextTrait.hpp
+++ b/serializer/include/serializer/framework/NamedTextTrait.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include "serializer/framework/Child.hpp"
 #include "utilities/TypeList.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -59,4 +59,4 @@ const char *NamedTextTrait<T, _tag, o, C>::tag = _tag;
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/Polymorphism.hpp
+++ b/serializer/include/serializer/framework/Polymorphism.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -106,4 +106,4 @@ const char *PolymorphismTrait<mTag, B, S>::tag = mTag;
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/SetterHelper.hpp
+++ b/serializer/include/serializer/framework/SetterHelper.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -66,4 +66,4 @@ struct SetterHelper<Ret (*)(Class, Arg), setter>
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/include/serializer/framework/TextNode.hpp
+++ b/serializer/include/serializer/framework/TextNode.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "serializer/framework/ConvertorPolicy.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -49,4 +49,4 @@ struct TextTrait
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/serializer/test/ConvertToStringUnitTest.cpp
+++ b/serializer/test/ConvertToStringUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #include "serializer/framework/ConvertToString.hpp"
 #include <gtest/gtest.h>
 
-using namespace audio_comms::utilities::serializer;
+using namespace audio_utilities::utilities::serializer;
 
 
 template <typename Source>

--- a/serializer/test/HelpersUnitTest.cpp
+++ b/serializer/test/HelpersUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@
 #include <utilities/TypeTraits.hpp>
 #include <gtest/gtest.h>
 
-using namespace audio_comms::utilities;
-using namespace audio_comms::utilities::serializer;
+using namespace audio_utilities::utilities;
+using namespace audio_utilities::utilities::serializer;
 
 // An abstract containor with serveral accessors
 template <typename T>

--- a/signal-processing/Android.mk
+++ b/signal-processing/Android.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2015 Intel Corporation
+# Copyright 2014-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ include $(CLEAR_VARS)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 
-LOCAL_MODULE := libaudio_comms_signal_processing
+LOCAL_MODULE := libaudio_utilities_signal_processing
 
 include $(BUILD_STATIC_LIBRARY)
 
@@ -34,7 +34,7 @@ include $(CLEAR_VARS)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 
-LOCAL_MODULE := libaudio_comms_signal_processing_host
+LOCAL_MODULE := libaudio_utilities_signal_processing_host
 
 LOCAL_CFLAGS = -O0 --coverage
 
@@ -49,7 +49,7 @@ endif
 ifeq (ENABLE_HOST_VERSION,1)
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := libaudio_comms_signal_processing_unit_test_host
+LOCAL_MODULE := libaudio_utilities_signal_processing_unit_test_host
 
 LOCAL_SRC_FILES := test/SignalProcessingUnitTest.cpp
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
@@ -58,7 +58,7 @@ LOCAL_CFLAGS := -Wall -Werror -Wextra -ggdb3 -O0
 
 LOCAL_STATIC_LIBRARIES := \
     libacresult_host \
-    libaudio_comms_utilities_host
+    libaudio_utilities_host
 
 LOCAL_STRIP_MODULE := false
 
@@ -71,7 +71,7 @@ endif
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := libaudio_comms_signal_processing_unit_test
+LOCAL_MODULE := libaudio_utilities_signal_processing_unit_test
 
 LOCAL_SRC_FILES := test/SignalProcessingUnitTest.cpp
 
@@ -83,7 +83,7 @@ LOCAL_STRIP_MODULE := false
 
 LOCAL_STATIC_LIBRARIES := \
     libacresult \
-    libaudio_comms_utilities
+    libaudio_utilities
 
 include $(BUILD_NATIVE_TEST)
 

--- a/signal-processing/include/signal-processing/SignalProcessing.hpp
+++ b/signal-processing/include/signal-processing/SignalProcessing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <limits>
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {

--- a/signal-processing/test/SignalProcessingUnitTest.cpp
+++ b/signal-processing/test/SignalProcessingUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2014 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 #include <gtest/gtest.h>
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -423,4 +423,4 @@ AUDIOUTILITIES_TYPED_TEST(ConstSignalCrossCorrelationTest, SignalProcessingTestT
 
 } /* namespace signal_processing */
 } /* namespace utilities */
-} /* namespace audio_comms */
+} /* namespace audio_utilities */

--- a/signal-processing/test/TypedTest.hpp
+++ b/signal-processing/test/TypedTest.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2014 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
     }
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {

--- a/src/Thread.cpp
+++ b/src/Thread.cpp
@@ -1,6 +1,6 @@
 /* Thread.cpp
 **
-** Copyright 2013-2015 Intel Corporation
+** Copyright 2013-2017 Intel Corporation
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <sys/syscall.h>
 #include <sstream>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -97,4 +97,4 @@ std::string Thread::getTid()
 }
 
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/test/ThreadUnitTest.cpp
+++ b/test/ThreadUnitTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-using audio_comms::cme::common::Thread;
+using audio_utilities::cme::common::Thread;
 
 TEST(Thread, startStop)
 {

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright 2013-2016 Intel Corporation
+# Copyright 2013-2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,15 +32,15 @@ common_static_libs := \
     libacserializer \
     libacresult \
     libtinyxml2 \
-    libaudio_comms_convert_includes \
-    libaudio_comms_utilities
+    libaudio_utilities_convert_includes \
+    libaudio_utilities
 
 common_static_libs_host := \
     libacserializer_host \
     libacresult_host \
     libtinyxml2 \
-    libaudio_comms_convert_includes_host \
-    libaudio_comms_utilities_host
+    libaudio_utilities_convert_includes_host \
+    libaudio_utilities_host
 
 common_shared_libs :=
 

--- a/xmlserializer/include/xmlserializer/CollectionImplementation.hpp
+++ b/xmlserializer/include/xmlserializer/CollectionImplementation.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 #include "utilities/TypeTraits.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -140,4 +140,4 @@ private:
 } // namespace detail
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/xmlserializer/include/xmlserializer/PolymorphismImplementation.hpp
+++ b/xmlserializer/include/xmlserializer/PolymorphismImplementation.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2014-2016 Intel Corporation
+ * Copyright 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "serializer/framework/Polymorphism.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -151,4 +151,4 @@ struct Deleter<serializer::PolymorphismTrait<tag, Base, SuportedTypelist>, takeO
 } // namespace detail
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/xmlserializer/include/xmlserializer/Result.hpp
+++ b/xmlserializer/include/xmlserializer/Result.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2014 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include <result/Result.hpp>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -77,4 +77,4 @@ typedef result::Result<detail::ResultTrait> Result;
 
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/xmlserializer/include/xmlserializer/Serializer.hpp
+++ b/xmlserializer/include/xmlserializer/Serializer.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include <istream>
 
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -209,4 +209,4 @@ private:
 
 } // namespace xmlserializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/xmlserializer/include/xmlserializer/TextNodeImplementation.hpp
+++ b/xmlserializer/include/xmlserializer/TextNodeImplementation.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "serializer/framework/TextNode.hpp"
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -86,4 +86,4 @@ public:
 
 } // namespace xmlserializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities

--- a/xmlserializer/include/xmlserializer/XmlSerializer.hpp
+++ b/xmlserializer/include/xmlserializer/XmlSerializer.hpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include "utilities/TypeList.hpp"
 #include <tinyxml2.h>
 
-namespace audio_comms
+namespace audio_utilities
 {
 namespace utilities
 {
@@ -228,7 +228,7 @@ private:
 } // namespace detail
 } // namespace serializer
 } // namespace utilities
-} // namespace audio_comms
+} // namespace audio_utilities
 
 #include "xmlserializer/TextNodeImplementation.hpp"
 #include "xmlserializer/CollectionImplementation.hpp"

--- a/xmlserializer/test/SerializerUnitTest.cpp
+++ b/xmlserializer/test/SerializerUnitTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @section License
  *
- * Copyright 2013-2016 Intel Corporation
+ * Copyright 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@
 #include <string>
 #include <list>
 
-using namespace audio_comms::utilities::xmlserializer;
-using namespace audio_comms::utilities::serializer;
+using namespace audio_utilities::utilities::xmlserializer;
+using namespace audio_utilities::utilities::serializer;
 
 template <class Result>
 void ASSERT_RESULT_SUCCESS(Result res)


### PR DESCRIPTION
@plbossart, @cc6565 final renaming as per internal tree comment.

In order to remove legacy audio_comms branding the namespace is
rename to audio_utilities.

Jira: None

Test: Build and run undr Intel Nuc.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>